### PR TITLE
Accept multiple verifier functions

### DIFF
--- a/src/caveat.rs
+++ b/src/caveat.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+
 #[derive(Clone)]
 pub struct Predicate(pub Vec<u8>);
 
@@ -31,5 +33,12 @@ impl Caveat {
             verification_id: None,
             caveat_location: Some(caveat_location),
         }
+    }
+}
+
+impl fmt::Display for Caveat {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let caveat_id = String::from_utf8(self.caveat_id.clone()).unwrap();
+        write!(f, "{}", &caveat_id)
     }
 }


### PR DESCRIPTION
I've been interested in Rust for a while and thought contributing here would be a good way to get my feet wet.

Currently rust-macaroons accepts a single `matcher` function and then passes each caveat to it for verification. 

In my opinion the interface would be improved by accepting a vector of verifier functions (`matchers` in rust-macaroon parlance), so that "prefix" matching logic can be contained within small caveat verifier rather than forcing a user to manage the composition themselves. (Interested to know if there was a reason for that choice originally - is there some nice property that makes it desirable to only register a single verifier function?)

Implemented the above idea after going through the rust book - if you agree with the basic premise please review the code since I'm definitely new to it!

Thanks!