### PR TITLE
Remove support for the location tag

### DIFF
--- a/src/token.rs
+++ b/src/token.rs
@@ -15,7 +15,6 @@ const PACKET_PREFIX_LENGTH: usize = 4;
 const MAX_PACKET_LENGTH: usize = 65535;
 
 pub struct Token {
-    pub location: Vec<u8>,
     pub identifier: Vec<u8>,
     pub caveats: Vec<Caveat>,
     pub tag: Tag,
@@ -28,12 +27,11 @@ struct Packet {
 }
 
 impl Token {
-    pub fn new(key: &Vec<u8>, identifier: Vec<u8>, location: Vec<u8>) -> Token {
+    pub fn new(key: &Vec<u8>, identifier: Vec<u8>) -> Token {
         let Tag(personalized_key) = authenticate(&key, &Key(*KEY_GENERATOR));
         let tag = authenticate(&identifier, &Key(personalized_key));
 
         Token {
-            location: location,
             identifier: identifier,
             caveats: Vec::new(),
             tag: tag,
@@ -41,7 +39,6 @@ impl Token {
     }
 
     pub fn deserialize(macaroon: Vec<u8>) -> Result<Token, &'static str> {
-        let mut location: Option<Vec<u8>> = None;
         let mut identifier: Option<Vec<u8>> = None;
         let mut caveats: Vec<Caveat> = Vec::new();
         let mut tag: Option<Tag> = None;
@@ -62,7 +59,7 @@ impl Token {
             index += packet.length;
 
             match &packet.id[..] {
-                b"location" => location = Some(packet.value),
+                b"location" => (), // Ignored as malleable data for informational use only
                 b"identifier" => identifier = Some(packet.value),
                 b"cid" => caveats.push(Caveat::first_party(Predicate(packet.value))),
                 b"vid" | b"cl" => {
@@ -104,18 +101,15 @@ impl Token {
             }
         }
 
-        if location == None {
-            return Err("no 'location' found");
-        }
         if identifier == None {
             return Err("no 'identifier' found");
         }
+
         if tag == None {
             return Err("no 'signature' found");
         }
 
         let token = Token {
-            location: location.unwrap(),
             identifier: identifier.unwrap(),
             caveats: caveats,
             tag: tag.unwrap(),
@@ -195,14 +189,13 @@ impl Token {
 
         Token {
             identifier: self.identifier.clone(),
-            location: self.location.clone(),
             caveats: new_caveats,
             tag: new_tag,
         }
     }
 
     pub fn verify(&self, key: &Vec<u8>) -> bool {
-        let mut verify_token = Token::new(&key, self.identifier.clone(), self.location.clone());
+        let mut verify_token = Token::new(&key, self.identifier.clone());
 
         for caveat in &self.caveats {
             verify_token = verify_token.add_caveat(&caveat)
@@ -215,7 +208,6 @@ impl Token {
         // TODO: estimate capacity and use Vec::with_capacity
         let mut result: Vec<u8> = Vec::new();
 
-        Token::packetize(&mut result, "location", &self.location);
         Token::packetize(&mut result, "identifier", &self.identifier);
 
         for caveat in self.caveats.iter() {

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -25,10 +25,6 @@ fn example_id() -> Vec<u8> {
     Vec::from("we used our secret key")
 }
 
-fn example_uri() -> Vec<u8> {
-    Vec::from("http://mybank/")
-}
-
 fn example_first_party_caveat() -> Caveat {
     Caveat::first_party(Predicate(Vec::from("test = caveat")))
 }
@@ -89,18 +85,17 @@ fn example_third_party_caveat() -> Caveat {
 }
 
 fn example_token() -> Token {
-    Token::new(&example_key(), example_id(), example_uri())
+    Token::new(&example_key(), example_id())
 }
 
 fn example_serialized_with_first_party_caveats() -> Vec<u8> {
-    Vec::from("MDAxY2xvY2F0aW9uIGh0dHA6Ly9teWJhbmsvCjAwMjZpZGVudGlmaWVyIHdlIHVzZWQgb3VyIHNlY3JldCB\
-               rZXkKMDAxNmNpZCB0ZXN0ID0gY2F2ZWF0CjAwMmZzaWduYXR1cmUgGXusegRK8zMyhluSZuJtSTvdZopmDk\
-               TYjOGpmMI9vWcK")
+    Vec::from("MDAyNmlkZW50aWZpZXIgd2UgdXNlZCBvdXIgc2VjcmV0IGtleQowMDE2Y2lkIHRlc3QgPSBjYXZlYXQKMDA\
+               yZnNpZ25hdHVyZSAZe6x6BErzMzKGW5Jm4m1JO91mimYORNiM4amYwj29Zwo")
 }
 
 #[test]
 fn empty_macaroon_signature() {
-    let token = Token::new(&example_key(), example_id(), example_uri());
+    let token = Token::new(&example_key(), example_id());
     let Tag(actual_tag) = token.tag;
 
     assert_eq!(EMPTY_TAG, actual_tag)
@@ -141,7 +136,6 @@ fn binary_serialization() {
 fn binary_deserialization() {
     let token = Token::deserialize(example_serialized_with_first_party_caveats()).unwrap();
 
-    assert_eq!(example_uri(), token.location);
     assert_eq!(example_id(), token.identifier);
 
     let Tag(actual_tag) = token.tag;


### PR DESCRIPTION
The location tag is malleable and therefore potentially attacker-controlled. Unlike other caveats it can be removed or manipulated by an attacker holding a Macaroon. This is surprising to me, and something I consider to be an unnecessarily sharp edge in the format's design. See:

http://www.thoughtcrime.org/blog/the-cryptographic-doom-principle/

libmacaroons does not expose this field, which seems like a good idea to me, so I'm following suit.

This change ignores the location field if present in Macaroons, and otherwise removes it from macaroons::token::Token.

cc @ecordell 