### PR TITLE
Return errors for out-of-order V1 packets

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -28,7 +28,7 @@ impl StdError for Error {
             Error::MalformedPacket => "packet not properly structured",
             Error::PacketOrdering => "packet types are not in the right order",
             Error::UnknownPacketType => "packet found with unknown type",
-            Error::MissingIdentifier => "no 'identifier' found in token",
+            Error::MissingIdentifier => "no 'identifier' found at beginning of token",
             Error::MissingSignature => "no 'signature' found in token",
         }
     }


### PR DESCRIPTION
Another error handling improvement: this should cover most ordering related problems with the V1 format. It previously allowed all sorts of incorrect orderings.

I'm not sure all cases with third party caveats are fully handled. Some fuzzing might be nice.

I guess this is what you get with a hand-rolled parser. Seems like nom will be nice for the V2 format, though.