### PR TITLE
Return Results for verification (instead of bool)

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -3,6 +3,8 @@ use std::error::Error as StdError;
 
 #[derive(Debug, Eq, PartialEq, Copy, Clone)]
 pub enum Error {
+    VerificationFailed,
+    FirstPartyCaveatFailed,
     Base64,
     PacketLength,
     SignatureLength,
@@ -22,6 +24,8 @@ impl fmt::Display for Error {
 impl StdError for Error {
     fn description(&self) -> &str {
         match *self {
+            Error::VerificationFailed => "the token is inauthentic",
+            Error::FirstPartyCaveatFailed => "a first-party caveat failed to verify",
             Error::Base64 => "unable to decode Base64",
             Error::PacketLength => "unable to decode packet length, or packet too long",
             Error::SignatureLength => "signature length incorrect",

--- a/src/token.rs
+++ b/src/token.rs
@@ -9,5 +9,5 @@ pub trait Token {
     fn deserialize(macaroon: Vec<u8>) -> Result<Self> where Self: Sized;
     fn serialize(&self) -> Result<Vec<u8>>;
     fn add_caveat(&self, caveat: &Caveat) -> Self;
-    fn verify(&self, key: &[u8]) -> bool;
+    fn verify(&self, key: &[u8]) -> Result<()>;
 }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -150,9 +150,8 @@ fn binary_deserialization() {
 fn simple_verification() {
     let token = example_token().add_caveat(&example_first_party_caveat());
 
-    assert!(token.verify(&example_key()), "verifies with valid key");
-    assert!(!token.verify(&invalid_key()),
-            "doesn't verify with invalid key");
+    assert!(token.verify(&example_key()).is_ok(), "verifies with valid key");
+    assert!(token.verify(&invalid_key()).is_err(), "doesn't verify with invalid key");
 }
 
 #[test]
@@ -162,14 +161,14 @@ fn verifying_predicates() {
         .add_caveat(&example_first_party_caveat_different_prefix());
 
     let matching_verifier = Verifier::new(vec![Box::new(verify_caveat)]);
-    assert!(matching_verifier.verify(&example_key(), &token));
-    assert!(!matching_verifier.verify(&invalid_key(), &token));
+    assert!(matching_verifier.verify(&example_key(), &token).is_ok());
+    assert!(matching_verifier.verify(&invalid_key(), &token).is_err());
     
     let non_matching_verifier = Verifier::new(vec![Box::new(verify_wrong_value)]);
-    assert!(!non_matching_verifier.verify(&example_key(), &token));
-    assert!(!non_matching_verifier.verify(&invalid_key(), &token));
+    assert!(non_matching_verifier.verify(&example_key(), &token).is_err());
+    assert!(non_matching_verifier.verify(&invalid_key(), &token).is_err());
 
     let multiple_verifier = Verifier::new(vec![Box::new(verify_caveat), Box::new(verify_other)]);
-    assert!(multiple_verifier.verify(&example_key(), &token));
+    assert!(multiple_verifier.verify(&example_key(), &token).is_ok());
 
 }


### PR DESCRIPTION
This ensures the compiler warns you when results aren't consumed, so you don't accidentally ignore a failed verification.